### PR TITLE
Use lexical binding as default

### DIFF
--- a/rubocop.el
+++ b/rubocop.el
@@ -1,4 +1,4 @@
-;;; rubocop.el --- An Emacs interface for RuboCop
+;;; rubocop.el --- An Emacs interface for RuboCop -*- lexical-binding: t -*-
 
 ;; Copyright © 2011-2013 Bozhidar Batsov
 
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/bbatsov/rubocop-emacs
 ;; Version: 0.3
 ;; Keywords: project, convenience
-;; Package-Requires: ((dash "1.0.0"))
+;; Package-Requires: ((dash "1.0.0") (emacs "24"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
The `recompile` command won't work since the definitions of `file-name`
in `rubocop--file-command` (line 122) and `directory` in
`rubocop--dir-command` (line 86) won't be available in the lambdas given
to the `compilation-start` function, since Emacs does not use lexical scope by 
default.

By adding lexical binding as a default option for the file, the problem
is seamlessly solved (apparently).

Although I can sort of `recompile` by repeating the rubocop command with the
provided keybindings, I rather have the ability to just press <kbd>g</kbd> in
the compilation buffer or use my custom recompile binding.
