### PR TITLE
do not try tramp on windows

### DIFF
--- a/rubocop.el
+++ b/rubocop.el
@@ -60,10 +60,10 @@
 
 (defun rubocop-local-file-name (file-name)
   "Retrieve local filename if FILE-NAME is opened via TRAMP."
-  (cond ((tramp-tramp-file-p file-name)
+  (cond ((eq system-type 'windows-nt) file-name)
+        ((tramp-tramp-file-p file-name)
          (tramp-file-name-localname (tramp-dissect-file-name file-name)))
-        (t
-         file-name)))
+        (t file-name)))
 
 (defun rubocop-project-root ()
   "Retrieve the root directory of a project if available.


### PR DESCRIPTION
When I run rubocop on windows emacs environment, i get this error

```
Symbol's function definition is void: tramp-tramp-file-p
```

I just made quick fix which just works for me. I am not sure whether this is good or bad. Please review this issue.