### PR TITLE
Load tramp dependency

### DIFF
--- a/rubocop.el
+++ b/rubocop.el
@@ -35,6 +35,7 @@
 ;;; Code:
 
 (require 'dash)
+(require 'tramp)
 
 (defgroup rubocop nil
   "An Emacs interface for RuboCop."


### PR DESCRIPTION
Fixes the "Symbol's function definition is void: tramp-tramp-file-p" error