### PR TITLE
Fix byte-compile warning about unused variable

### DIFF
--- a/rubocop.el
+++ b/rubocop.el
@@ -125,7 +125,7 @@ Alternatively prompt user for directory."
         (compilation-start
          (concat command " " (rubocop-local-file-name file-name))
          'compilation-mode
-         (lambda (arg) (rubocop-buffer-name file-name)))
+         (lambda (_arg) (rubocop-buffer-name file-name)))
       (error "Buffer is not visiting a file"))))
 
 ;;;###autoload


### PR DESCRIPTION
This change fixes following a byte-compile warning.
```
rubocop.el:120:1:Warning: Unused lexical argument `arg' 
```