### PR TITLE
Consider rubocop installed if bundled

### DIFF
--- a/rubocop.el
+++ b/rubocop.el
@@ -79,6 +79,10 @@ The current directory is assumed to be the project's root otherwise."
   "Generate a name for the RuboCop buffer from FILE-OR-DIR."
   (concat "*RuboCop " file-or-dir "*"))
 
+(defun rubocop-build-command (command path)
+  "Compose the full command to be run, prefixing with `bundle exec` if rubocop is bundled"
+  (concat (if (rubocop-bundled-p) "bundle exec " "") command " " path))
+
 (defun rubocop--dir-command (command &optional directory)
   "Run COMMAND on DIRECTORY (if present).
 Alternatively prompt user for directory."
@@ -87,7 +91,7 @@ Alternatively prompt user for directory."
          (or directory
              (read-directory-name "Select directory:"))))
     (compilation-start
-     (concat command " " (rubocop-local-file-name directory))
+     (rubocop-build-command command (rubocop-local-file-name directory))
      'compilation-mode
      (lambda (arg) (message arg) (rubocop-buffer-name directory)))))
 
@@ -123,7 +127,7 @@ Alternatively prompt user for directory."
   (let ((file-name (buffer-file-name (current-buffer))))
     (if file-name
         (compilation-start
-         (concat command " " (rubocop-local-file-name file-name))
+         (rubocop-build-command command (rubocop-local-file-name file-name))
          'compilation-mode
          (lambda (_arg) (rubocop-buffer-name file-name)))
       (error "Buffer is not visiting a file"))))

--- a/rubocop.el
+++ b/rubocop.el
@@ -140,9 +140,17 @@ Alternatively prompt user for directory."
   (interactive)
   (rubocop--file-command rubocop-autocorrect-command))
 
+(defun rubocop-bundled-p ()
+  "Check if rubocop has been bundled."
+  (let ((gemfile-lock (expand-file-name "Gemfile.lock" (rubocop-project-root))))
+    (when (file-exists-p gemfile-lock)
+      (with-temp-buffer
+        (insert-file-contents gemfile-lock)
+        (re-search-forward "rubocop" nil t)))))
+
 (defun rubocop-ensure-installed ()
   "Check if RuboCop is installed."
-  (unless (executable-find "rubocop")
+  (unless (or (executable-find "rubocop") (rubocop-bundled-p))
     (error "RuboCop is not installed")))
 
 ;;; Minor mode


### PR DESCRIPTION
For those that vendorize their gems, the rubocop binary may not be on
the exec path, even if it has been bundled. For such users, their check
command will need to be `bundle exec rubocop` instead. This change will
allow rubocop-emacs to proceed with using the bundled rubocop if rubocop
is not found on the exec path.

Fixes https://github.com/bbatsov/rubocop-emacs/issues/17
