### PR TITLE
Expand the project root path

### DIFF
--- a/rubocop.el
+++ b/rubocop.el
@@ -72,6 +72,7 @@ The current directory is assumed to be the project's root otherwise."
   (or (->> rubocop-project-root-files
         (--map (locate-dominating-file default-directory it))
         (-remove #'null)
+	(--map (expand-file-name it))
         (car))
       (error "You're not into a project")))
 


### PR DESCRIPTION
This is to fix rubocop on windows. Without the expansion rubocop tries
to run "rubocop -format emacs ~/PROJ" which leads to rubocop exiting
with the error "Is a directory @ rb_sysopen - C:/Users/USER/PROJ"