### PR TITLE
Add an option to execute rubocop in a chroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,13 @@ You can change the shell command used by `rubocop-autocorrect-*` commands via `r
 
 You can change the shell command used by `rubocop-format-*` commands via `rubocop-format-command`.
 
-## Alternatives
+You can run rubocop inside a chroot via schroot by setting:
+
+``` emacs-lisp
+(setq rubocop-run-in-chroot t)
+```
+
+## alternatives
 
 [Flycheck](https://www.flycheck.org) and Flymake (Emacs built-in) provide more sophisticated integration with various lint tools, including RuboCop.
 

--- a/rubocop.el
+++ b/rubocop.el
@@ -85,6 +85,11 @@ It's basically auto-correction limited to layout cops."
   :group 'rubocop
   :type 'boolean)
 
+(defcustom rubocop-run-in-chroot nil
+  "Runs rubocop inside a chroot via schroot setting the cwd to the project's root."
+  :group 'rubocop
+  :type 'boolean)
+
 (defun rubocop-local-file-name (file-name)
   "Retrieve local filename if FILE-NAME is opened via TRAMP."
   (cond ((tramp-tramp-file-p file-name)
@@ -128,6 +133,7 @@ When NO-ERROR is non-nil returns nil instead of raise an error."
   "Build the full command to be run based on COMMAND and PATH.
 The command will be prefixed with `bundle exec` if RuboCop is bundled."
   (concat
+   (if rubocop-run-in-chroot (format "schroot -d %s -- " (rubocop-project-root)))
    (if (and (not rubocop-prefer-system-executable) (rubocop-bundled-p)) "bundle exec " "")
    command
    (rubocop-build-requires)


### PR DESCRIPTION
I execute Ruby stuff in a chroot (via Debian's [schroot](https://manpages.debian.org/unstable/schroot/schroot.1.en.html)) because the Ruby version available in the system is not the one I want. I have a hack in my `init.el` to override [`rubocop-build-command`](https://github.com/nbarrientos/dotfiles/blob/cern/emacs/emacs.el#L155) for this matter but I thought that it might be useful for others so I'm proposing this change putting the feature behind a boolean switch defaulting to `nil`.

Changing the working directory to the project's root when entering the chroot is necessary for bundled setups to work.