### PR TITLE
Do not check for a local executable if run in chroot

### DIFF
--- a/rubocop.el
+++ b/rubocop.el
@@ -254,7 +254,7 @@ See also `rubocop-format-on-save' and `rubocop-autocorrect-on-save'."
 
 (defun rubocop-ensure-installed ()
   "Check if RuboCop is installed."
-  (unless (or (executable-find "rubocop") (rubocop-bundled-p))
+  (unless (or (executable-find "rubocop") (rubocop-bundled-p) rubocop-run-in-chroot)
     (error "RuboCop is not installed")))
 
 ;;; Minor mode


### PR DESCRIPTION
It should be okay not to have rubocop installed at system level if it's meant to be run in a chroot.