### PR TITLE
Add option to run rubocop with the `--server` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ You can run rubocop inside a chroot via schroot by setting:
 (setq rubocop-run-in-chroot t)
 ```
 
+You can run rubocop with the `--server` flag by setting:
+
+``` emacs-lisp
+(setq rubocop-use-server t)
+```
+
 ## Alternatives
 
 [Flycheck](https://www.flycheck.org) and Flymake (Emacs built-in) provide more sophisticated integration with various lint tools, including RuboCop.

--- a/rubocop.el
+++ b/rubocop.el
@@ -99,6 +99,12 @@ It's basically auto-correction limited to layout cops."
   :type 'boolean
   :package-version '(rubocop . "0.7.0"))
 
+(defcustom rubocop-use-server nil
+  "Runs rubocop with the '--server' flag."
+  :group 'rubocop
+  :type 'boolean
+  :package-version '(rubocop . "0.7.0"))
+
 (defun rubocop-local-file-name (file-name)
   "Retrieve local filename if FILE-NAME is opened via TRAMP."
   (cond ((tramp-tramp-file-p file-name)
@@ -145,6 +151,7 @@ The command will be prefixed with `bundle exec` if RuboCop is bundled."
    (if rubocop-run-in-chroot (format "schroot -d %s -- " (rubocop-project-root)))
    (if (and (not rubocop-prefer-system-executable) (rubocop-bundled-p)) "bundle exec " "")
    command
+   (if rubocop-use-server " --server ")
    (rubocop-build-requires)
    " "
    path))


### PR DESCRIPTION
This adds a variable `rubocop-use-server` that will add `--server` to the rubocop command.