### PR TITLE
[fix]: add force-exclusion params for rubocop build command

### DIFF
--- a/rubocop.el
+++ b/rubocop.el
@@ -155,11 +155,11 @@ When NO-ERROR is non-nil returns nil instead of raise an error."
 The command will be prefixed with `bundle exec` if RuboCop is bundled."
   (concat
    (if rubocop-run-in-chroot (format "schroot -d %s -- " (rubocop-project-root)))
+   (if (and (not rubocop-prefer-system-executable) (rubocop-bundled-p)) "bundle exec " "")
    "rubocop"
    " "
-   ;; (if (and (not rubocop-prefer-system-executable) (rubocop-bundled-p)) "bundle exec " "")
    (if (and (or force-exclusion rubocop-force-exclusion)  rubocop-file-path)
-       (format "--force-exclusion %s " rubocop-file-path))
+       (format "--force-exclusion -c %s " rubocop-file-path))
    command
    (rubocop-build-requires)
    " "


### PR DESCRIPTION
This PR introduces a new option rubocop-force-exclusion that allows users to enforce the Exclude configurations defined in their .rubocop.yml file. When enabled, Rubocop will skip formatting and correcting files listed in the Exclude section, ensuring that users have full control over which files are processed.
Motivation

Currently, Rubocop may automatically format or correct files even if they are explicitly excluded in the .rubocop.yml file. This behavior can be problematic for users who want to exclude certain files (e.g., auto-generated files, third-party code, or files with specific formatting requirements). This PR addresses this issue by adding an option to respect the Exclude configurations.
Changes

   Added a new customizable variable rubocop-force-exclusion (default: nil).

       When set to t, Rubocop will skip files listed in the Exclude section of .rubocop.yml.

       When nil, the behavior remains unchanged (files may still be formatted or corrected regardless of Exclude).
       
      